### PR TITLE
Limit converted pdf files per repository

### DIFF
--- a/src/main/java/com/cloudogu/scm/gotenberg/CacheFactory.java
+++ b/src/main/java/com/cloudogu/scm/gotenberg/CacheFactory.java
@@ -1,0 +1,141 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.cloudogu.scm.gotenberg;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.ByteStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sonia.scm.repository.Repository;
+import sonia.scm.store.Blob;
+import sonia.scm.store.BlobStore;
+import sonia.scm.store.BlobStoreFactory;
+import sonia.scm.store.StoreException;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Singleton
+public final class CacheFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CacheFactory.class);
+
+  private static final String STORE = "gotenberg";
+
+  private final BlobStoreFactory blobStoreFactory;
+  private final Map<String, Cache> caches = new ConcurrentHashMap<>();
+  private final int cacheSize;
+
+  @Inject
+  public CacheFactory(BlobStoreFactory blobStoreFactory) {
+    this(blobStoreFactory, 20);
+  }
+
+  @VisibleForTesting
+  CacheFactory(BlobStoreFactory blobStoreFactory, int cacheSize) {
+    this.blobStoreFactory = blobStoreFactory;
+    this.cacheSize = cacheSize;
+  }
+
+  public Cache get(Repository repository) {
+    return caches.computeIfAbsent(
+      repository.getId(),
+      id -> new Cache(blobStoreFactory.withName(STORE).forRepository(repository).build())
+    );
+  }
+
+  public class Cache {
+
+    private final BlobStore blobStore;
+    private final Map<String, Instant> lru = new HashMap<>();
+
+    private Cache(BlobStore blobStore) {
+      this.blobStore = blobStore;
+      blobStore.getAll().forEach(blob -> lru.put(blob.getId(), Instant.now()));
+      checkCacheSizeLimit();
+    }
+
+    public synchronized Optional<InputStream> get(RepositoryPath repositoryPath) {
+      String cacheKey = repositoryPath.getCacheKey();
+      Optional<Blob> optional = blobStore.getOptional(cacheKey);
+      if (optional.isPresent()) {
+        lru.put(cacheKey, Instant.now());
+      }
+      return optional.map(this::getInputStream);
+    }
+
+    private InputStream getInputStream(Blob blob) {
+      try {
+        return blob.getInputStream();
+      } catch (IOException e) {
+        throw new StoreException("failed to open input stream", e);
+      }
+    }
+
+    public synchronized void set(RepositoryPath repositoryPath, InputStream content) throws IOException {
+      String cacheKey = repositoryPath.getCacheKey();
+      Blob blob = blobStore.create(cacheKey);
+      try (OutputStream output = blob.getOutputStream()) {
+        ByteStreams.copy(content, output);
+        blob.commit();
+      }
+      lru.put(cacheKey, Instant.now());
+      checkCacheSizeLimit();
+    }
+
+    private void checkCacheSizeLimit() {
+      while (lru.size() > 0 && lru.size() > cacheSize) {
+        LOG.debug("size limit of {} reached by {}, remove eldest entry", cacheSize, lru.size());
+        removeEldest();
+      }
+    }
+
+    private void removeEldest() {
+      Map.Entry<String, Instant> eldest = null;
+      for (Map.Entry<String, Instant> e : lru.entrySet()) {
+        if (eldest == null || e.getValue().isBefore(eldest.getValue())) {
+          eldest = e;
+        }
+      }
+
+      if (eldest == null) {
+        throw new IllegalStateException("remove eldest should not be called if the map is empty");
+      }
+
+      String key = eldest.getKey();
+      LOG.debug("remove eldest entry from blob store: {}", key);
+      blobStore.remove(key);
+      lru.remove(key);
+    }
+  }
+}

--- a/src/test/java/com/cloudogu/scm/gotenberg/CacheFactoryTest.java
+++ b/src/test/java/com/cloudogu/scm/gotenberg/CacheFactoryTest.java
@@ -1,0 +1,90 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.cloudogu.scm.gotenberg;
+
+import com.google.common.io.ByteStreams;
+import org.junit.jupiter.api.Test;
+import sonia.scm.repository.Repository;
+import sonia.scm.repository.RepositoryTestData;
+import sonia.scm.store.InMemoryBlobStoreFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CacheFactoryTest {
+
+  @Test
+  void shouldCache() throws IOException {
+    Repository repository = RepositoryTestData.createHeartOfGold();
+
+    CacheFactory factory = new CacheFactory(new InMemoryBlobStoreFactory());
+
+    CacheFactory.Cache cache = factory.get(repository);
+
+    RepositoryPath path = path(repository, "a.txt");
+    cache.set(path, stream("Hello"));
+
+    assertThat(cache.get(path)).hasValueSatisfying(stream -> hasContent(stream, "Hello"));
+  }
+
+  @Test
+  void shouldRemoveEldest() throws IOException {
+    Repository repository = RepositoryTestData.createHeartOfGold();
+    CacheFactory factory = new CacheFactory(new InMemoryBlobStoreFactory(), 2);
+    CacheFactory.Cache cache = factory.get(repository);
+
+    cache.set(path(repository, "a.txt"), stream("Hello from a"));
+    cache.set(path(repository, "b.txt"), stream("Hello from b"));
+    cache.set(path(repository, "c.txt"), stream("Hello from c"));
+
+    assertThat(cache.get(path(repository, "a.txt"))).isEmpty();
+    assertThat(cache.get(path(repository, "b.txt")))
+      .hasValueSatisfying(stream -> hasContent(stream, "Hello from b"));
+    assertThat(cache.get(path(repository, "c.txt")))
+      .hasValueSatisfying(stream -> hasContent(stream, "Hello from c"));
+  }
+
+  private void hasContent(InputStream stream, String expected) {
+    try {
+      byte[] bytes = ByteStreams.toByteArray(stream);
+      assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo(expected);
+    } catch (IOException e) {
+      throw new IllegalStateException("failed to copy streams");
+    }
+  }
+
+  private InputStream stream(String content) {
+    return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private RepositoryPath path(Repository repository, String path) {
+    return new RepositoryPath(repository.getNamespace(), repository.getName(), "42", path);
+  }
+
+}

--- a/src/test/java/com/cloudogu/scm/gotenberg/PdfServiceTest.java
+++ b/src/test/java/com/cloudogu/scm/gotenberg/PdfServiceTest.java
@@ -64,7 +64,7 @@ class PdfServiceTest {
   void setUpObjectUnderTest() {
     pdfService = new PdfService(
       repositoryManager,
-      new InMemoryBlobStoreFactory(),
+      new CacheFactory(new InMemoryBlobStoreFactory()),
       fileResolver,
       converter
     );


### PR DESCRIPTION
## Proposed changes

Add a limit for the cached converted pdf's per repository. The default limit is 20.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
